### PR TITLE
Improve website layout

### DIFF
--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -33,6 +33,7 @@
     <link rel="stylesheet" href="./assets/css/style-no-dark-mode.css">
     <link rel="stylesheet" href="./assets/css/publications-no-dark-mode.css">
     {% endif %}
+    <link rel="stylesheet" href="./assets/css/custom.css">
 
   </head>
   <!-- Google tag (gtag.js) -->

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,0 +1,39 @@
+body {
+    background-color: #f5f5f5;
+    margin: 0;
+}
+
+.wrapper {
+    max-width: 900px;
+    margin: 2rem auto;
+    width: 100%;
+    background: #fff;
+    padding: 2rem;
+    border-radius: 6px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+header {
+    float: none;
+    position: static;
+    width: 100%;
+    padding-top: 1.5rem;
+    text-align: center;
+    margin-bottom: 2rem;
+}
+
+section {
+    float: none;
+    width: 100%;
+    padding-top: 0;
+    padding-bottom: 2rem;
+}
+
+footer {
+    float: none;
+    position: static;
+    width: 100%;
+    text-align: center;
+    padding: 1rem 0;
+    margin-top: 2rem;
+}

--- a/assets/css/font_sans_serif.css
+++ b/assets/css/font_sans_serif.css
@@ -1,7 +1,7 @@
 body {
-    background-color: #fff;
-    padding:50px;
-    font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-    color:#595959;
-    font-weight:400;
-  }
+    background-color: #f5f5f5;
+    padding: 20px;
+    font: 17px/1.7 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    color: #333;
+    font-weight: 400;
+}


### PR DESCRIPTION
## Summary
- add card-style wrapper and center layout
- increase base font size and body background color
- adjust spacing for header and footer

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_687274a0cee88326ba1fb5aa2f06d1a3